### PR TITLE
Ignore unknown items when selling junk

### DIFF
--- a/mods/sell-junk.lua
+++ b/mods/sell-junk.lua
@@ -86,6 +86,8 @@ module.enable = function(self)
     local _, icount = GetContainerItemInfo(bag, slot)
     local _, _, id = string.find(GetContainerItemLink(bag, slot), "item:(%d+):%d+:%d+:%d+")
     local price = ShaguTweaks.SellValueDB[tonumber(id)]
+    -- skip if item is missing from SellValueDB
+    if not price then return end
     if this.price then
       this.price = this.price + ( price * ( icount or 1 ) )
       this.count = this.count + 1


### PR DESCRIPTION
Some servers (e.g. Turtle WoW) have custom grey items, that are not present in SellValueDB.
To be on the safe side, skip over these items when selling junk. (Before this change, we would throw a lua error and sell nothing.)