### PR TITLE
Offcenter the debuff stacks

### DIFF
--- a/mods/target-debufftimer.lua
+++ b/mods/target-debufftimer.lua
@@ -21,7 +21,7 @@ local function CreateTextCooldown(cooldown)
   cooldown.readable.text = cooldown.readable:CreateFontString("pfCooldownFrameText", "OVERLAY")
 
   cooldown.readable.text:SetFont(STANDARD_TEXT_FONT, 10, "OUTLINE")
-  cooldown.readable.text:SetPoint("CENTER", cooldown.readable, "CENTER", 0, 0)
+  cooldown.readable.text:SetPoint("CENTER", cooldown.readable, "CENTER", -1.5, 4)
   cooldown.readable:SetScript("OnUpdate", function()
     parent = this:GetParent()
     if not parent then this:Hide() end


### PR DESCRIPTION
this makes it alot easier to see debuff stacks for armor penetration and crusdaer strike because it overlapped with the debuff timer.