### PR TITLE
Suggestion to add modules: Sticky markers and shiftclick action

### DIFF
--- a/ShaguTweaks.toc
+++ b/ShaguTweaks.toc
@@ -66,3 +66,5 @@ mods\unitframes-classportrait.lua
 mods\cooldown-numbers.lua
 mods\turtle-wow.lua
 mods\reduced-actionbar.lua
+mods\stickymarkers.lua
+mods\shiftclick-action.lua

--- a/mods/shiftclick-action.lua
+++ b/mods/shiftclick-action.lua
@@ -1,0 +1,24 @@
+local _G = ShaguTweaks.GetGlobalEnv()
+local hooksecurefunc = hooksecurefunc or ShaguTweaks.hooksecurefunc
+local GetExpansion = ShaguTweaks.GetExpansion
+
+local module = ShaguTweaks:register({
+  title = "Shiftclick Action",
+  description = "Allows shift-clicking on a locked actionbar to use the button instead of picking it up.",
+  expansions = { ["vanilla"] = true, ["tbc"] = nil },
+  category = "General",
+  enabled = true,
+})
+
+module.enable = function(self)
+  local HookPickupAction = PickupAction
+  function PickupAction(ActionButtonID)
+    if ( LOCK_ACTIONBAR == "1" ) then
+      if ( IsShiftKeyDown() ) then
+        UseAction(ActionButtonID, 1);
+      end
+      return
+	end
+    HookPickupAction(ActionButtonID)
+  end
+end

--- a/mods/stickymarkers.lua
+++ b/mods/stickymarkers.lua
@@ -1,0 +1,17 @@
+local _G = ShaguTweaks.GetGlobalEnv()
+local hooksecurefunc = hooksecurefunc or ShaguTweaks.hooksecurefunc
+local GetExpansion = ShaguTweaks.GetExpansion
+
+local module = ShaguTweaks:register({
+  title = "Sticky Markers",
+  description = "Enforce keeping raid markers instead of clearing them when applying existing mark to a unit.",
+  expansions = { ["vanilla"] = true, ["tbc"] = nil },
+  category = "Unit Frames",
+  enabled = true,
+})
+
+module.enable = function(self)
+  hooksecurefunc("SetRaidTargetIcon", function(unit, index)
+    SetRaidTarget(unit, index);
+  end)
+end


### PR DESCRIPTION
Sticky Markers helps with the issue of multiple people marking the same mob and removing each other's markers.
- Makes the keybinding and the unitframe button to set a raidmarker on a unit always apply that raidmarker on the unit, instead of clearing it when the unit already has that marker.

Shiftclick action is for people who want to shiftclick an action bar button like a macro that has a shift modifier
- Default UI always picks up the button on shift click even if the actionbar is locked, with this module enabled, shift clicking with locked action bar will use the action. Shift clicking or dragging with unlocked action bar to pick up the button is default UI functionality that is preserved by this hook.

discord name: omigawail