### PR TITLE
reduced-actionbar: bag QoL

### DIFF
--- a/mods/reduced-actionbar.lua
+++ b/mods/reduced-actionbar.lua
@@ -11,7 +11,7 @@ local module = ShaguTweaks:register({
 local function ReplaceBag()
   local id = this:GetID()
   if id ~= 0 then
-    id = 19 + id
+    id = ContainerIDToInventoryID(id)
     if CursorHasItem() then
       PutItemInBag(id)
     else

--- a/mods/reduced-actionbar.lua
+++ b/mods/reduced-actionbar.lua
@@ -6,6 +6,15 @@ local module = ShaguTweaks:register({
   enabled = nil,
 })
 
+local function ReplaceBag()
+  local id = 19 + this:GetID()
+  if CursorHasItem() then
+    PutItemInBag(id)
+  else
+    PickupBagFromSlot(id)
+  end
+end
+
 module.enable = function(self)
   -- general function to hide textures and frames
   local function hide(frame, texture)
@@ -134,5 +143,10 @@ module.enable = function(self)
     anchor = MultiBarBottomRight:IsVisible() and MultiBarBottomRight or anchor
     local pet_offset = PetActionBarFrame:IsVisible() and 40 or 0
     CastingBarFrame:SetPoint("BOTTOM", anchor, "TOP", 0, 10 + pet_offset)
+  end
+
+  -- enable picking up/replacing bags by clicking on the container frame portrait
+  for i = 2, 5 do
+    getglobal('ContainerFrame' .. i .. 'PortraitButton'):SetScript('OnClick', ReplaceBag)
   end
 end

--- a/mods/reduced-actionbar.lua
+++ b/mods/reduced-actionbar.lua
@@ -1,3 +1,5 @@
+local _G = ShaguTweaks.GetGlobalEnv()
+
 local module = ShaguTweaks:register({
   title = "Reduced Actionbar Size",
   description = "Reduces the actionbar size by removing several items such as the bag panel and microbar",
@@ -7,11 +9,14 @@ local module = ShaguTweaks:register({
 })
 
 local function ReplaceBag()
-  local id = 19 + this:GetID()
-  if CursorHasItem() then
-    PutItemInBag(id)
-  else
-    PickupBagFromSlot(id)
+  local id = this:GetID()
+  if id ~= 0 then
+    id = 19 + id
+    if CursorHasItem() then
+      PutItemInBag(id)
+    else
+      PickupBagFromSlot(id)
+    end
   end
 end
 
@@ -146,7 +151,7 @@ module.enable = function(self)
   end
 
   -- enable picking up/replacing bags by clicking on the container frame portrait
-  for i = 2, 5 do
-    getglobal('ContainerFrame' .. i .. 'PortraitButton'):SetScript('OnClick', ReplaceBag)
+  for i = 1, 5 do
+    _G["ContainerFrame" .. i .. "PortraitButton"]:SetScript("OnClick", ReplaceBag)
   end
 end


### PR DESCRIPTION
Hello shagu.

I added the option to replace a bag or pick it up without needing to disable the reduced actionbar option. To replace a bag, pick up a bag from one of your bags and click on the portrait of the desired bag that you want to replace. To pick up a bag, click on the portrait of the bag that you want to pick up. The bags need to be empty of course.

It's a simple addition but removes the hassle of needing to disable the reduced actionbar option just to manage your bags. The gif below is a bit wonky but it should suffice as a demonstration.

![peek](https://github.com/shagu/ShaguTweaks/assets/46632393/548db0dd-32ab-4a27-87bd-151284513e6b)
