### PR TITLE
turtle-wow: fix error when auto-dismount is not enabled

### DIFF
--- a/mods/item-colors.lua
+++ b/mods/item-colors.lua
@@ -140,10 +140,14 @@ module.enable = function(self)
             local link = GetContainerItemLink(id, button:GetID())
             if button and button:IsShown() and link then
               local _, _, istring  = string.find(link, "|H(.+)|h")
-              local _, _, quality = GetItemInfo(istring)
+              local _, _, quality, _, type = GetItemInfo(istring)
               if quality then
-                local r, g, b = GetItemQualityColor(quality)
-                button.ShaguTweaks_border:SetBackdropBorderColor(r,g,b)
+                if type == "Quest" then
+                  button.ShaguTweaks_border:SetBackdropBorderColor(1,0,0)
+                else
+                  local r, g, b = GetItemQualityColor(quality)
+                  button.ShaguTweaks_border:SetBackdropBorderColor(r,g,b)
+                end
               end
             end
           end

--- a/mods/turtle-wow.lua
+++ b/mods/turtle-wow.lua
@@ -60,7 +60,9 @@ module.enable = function(self)
   ShaguTweaks.SellValueDB = selldata
 
   -- add tree of life druid form to autoshift
-  table.insert(ShaguTweaks.dismount.shapeshifts, "ability_druid_treeoflife")
+  if ShaguTweaks.dismount then
+    table.insert(ShaguTweaks.dismount.shapeshifts, "ability_druid_treeoflife")
+  end
 end
 
 -- Turtle WoW specific libdebuff patches


### PR DESCRIPTION
Following error shows up when the turtle-wow module is enabled but auto-dismount is disabled:
![image](https://github.com/shagu/ShaguTweaks/assets/46632393/63edbfb7-068e-4552-8126-fcae27e9bba7)

