### PR TITLE
turtle-wow: fix error when auto-dismount is not enabled

### DIFF
--- a/mods/turtle-wow.lua
+++ b/mods/turtle-wow.lua
@@ -60,7 +60,9 @@ module.enable = function(self)
   ShaguTweaks.SellValueDB = selldata
 
   -- add tree of life druid form to autoshift
-  table.insert(ShaguTweaks.dismount.shapeshifts, "ability_druid_treeoflife")
+  if ShaguTweaks.dismount then
+    table.insert(ShaguTweaks.dismount.shapeshifts, "ability_druid_treeoflife")
+  end
 end
 
 -- Turtle WoW specific libdebuff patches


### PR DESCRIPTION
Fixes the following error that shows up when the turtle-wow module is enabled but auto-dismount is disabled: `attempt to index field 'dismount' (a nil value)`