### PR TITLE
equip-compare 2 fixes

### DIFF
--- a/mods/equip-compare.lua
+++ b/mods/equip-compare.lua
@@ -207,6 +207,7 @@ module.enable = function(self)
     local atlas = CreateFrame("Frame", nil, AtlasLootTooltip)
     atlas:SetScript("OnUpdate", function()
       ShowCompare(AtlasLootTooltip)
+      ShowCompare(AtlasLootTooltip2)
     end)
   end)
 end

--- a/mods/equip-compare.lua
+++ b/mods/equip-compare.lua
@@ -10,9 +10,10 @@ local module = ShaguTweaks:register({
 })
 
 module.enable = function(self)
+  local sides = { "Left", "Right" }
+
   local function AddHeader(tooltip)
     local name = tooltip:GetName()
-    local sides = { "Left", "Right" }
 
     -- shift all entries one line down
     for i=tooltip:NumLines(), 1, -1 do

--- a/mods/equip-compare.lua
+++ b/mods/equip-compare.lua
@@ -186,7 +186,11 @@ module.enable = function(self)
             local slotID_other = GetInventorySlotInfo(slots[slotType .. "_other"])
             ShoppingTooltip2:SetOwner(tooltip, "ANCHOR_NONE")
             ShoppingTooltip2:ClearAllPoints()
-            ShoppingTooltip2:SetPoint(anchor, ShoppingTooltip1, relative, 0, 0)
+            if ShoppingTooltip1:IsShown() then
+                ShoppingTooltip2:SetPoint(anchor, ShoppingTooltip1, relative, 0, 0)
+            else
+                ShoppingTooltip2:SetPoint(anchor, tooltip, relative, 0, 0)
+            end
             ShoppingTooltip2:SetInventoryItem("player", slotID_other)
             ShoppingTooltip2:Show()
             AddHeader(ShoppingTooltip2)


### PR DESCRIPTION
<img src="https://github.com/user-attachments/assets/86a4a722-346c-40db-9218-579fa194b659" width="300">
<img src="https://github.com/user-attachments/assets/52ccedaf-d44e-4a92-a4bc-c3a79ec55edc" width="300">

fixes this bug when you only have 1 ring or weapon equipped

<img src="https://github.com/user-attachments/assets/cf6b19ca-7498-416c-be23-35df5072ffad" width="400">

adds compare to second AtlasLoot tooltip that is shown in crafting for example

