### PR TITLE
Add support for Turtle WoW SA Dismount

### DIFF
--- a/mods/auto-dismount.lua
+++ b/mods/auto-dismount.lua
@@ -35,6 +35,11 @@ module.enable = function(self)
     "Riding",
     "根据骑术技能提高速度。",
     "又慢又稳......",
+
+    -- turtle-wow SA
+   "Lento y constante...",
+   "Aumenta la velocidad según tu habilidad de Montar.",
+    
   }
 
   -- shapeshift buff icons


### PR DESCRIPTION
This fix adds support for auto unmount with the South American Turtle WoW server.