### PR TITLE
[Bugfix] Correct TBC Shaman color

### DIFF
--- a/mods/blue-shaman.lua
+++ b/mods/blue-shaman.lua
@@ -18,7 +18,7 @@ module.enable = function(self)
     ["ROGUE"]   = { r = 1,    g = 0.96, b = 0.41, colorStr = "fffff569" },
     ["DRUID"]   = { r = 1,    g = 0.49, b = 0.04, colorStr = "ffff7d0a" },
     ["HUNTER"]  = { r = 0.67, g = 0.83, b = 0.45, colorStr = "ffabd473" },
-    ["SHAMAN"]  = { r = 0.14, g = 0.35, b = 1.0,  colorStr = "ff0070de" },
+    ["SHAMAN"]  = { r = 0.14, g = 0.35, b = 1.0,  colorStr = "ff2459ff" },
     ["PRIEST"]  = { r = 1,    g = 1,    b = 1,    colorStr = "ffffffff" },
     ["WARLOCK"] = { r = 0.58, g = 0.51, b = 0.79, colorStr = "ff9482c9" },
     ["PALADIN"] = { r = 0.96, g = 0.55, b = 0.73, colorStr = "fff58cba" },


### PR DESCRIPTION
I noticed the TBC shaman color was slightly off when using the `colorStr` and found that you were actually using the WOLK Shaman color for `colorStr` but the TBC color for the `RGB` values.

Here is what it looks like in game:
<img width="328" height="84" alt="image" src="https://github.com/user-attachments/assets/a821dd05-b24c-4557-a431-a048482dbf0b" />

More context here: https://wowpedia.fandom.com/wiki/Class_colors
> Patch 3.2.2 (2009-09-22): RAID_CLASS_COLORS added in FrameXML/Constants.lua, and Shaman changed from 2459FF to 0070DE.[[7]](https://wowpedia.fandom.com/wiki/Class_colors#cite_note-7)

## How I tested it
I checked all other colors with this code and they all seem to match:
```
local function printClass(class, shaguColors)
  DEFAULT_CHAT_FRAME:AddMessage(class.." RGB Blizzard", RAID_CLASS_COLORS[class].r, RAID_CLASS_COLORS[class].g, RAID_CLASS_COLORS[class].b)
  DEFAULT_CHAT_FRAME:AddMessage(class.." RGB Shagu", shaguColors[class].r, shaguColors[class].g, shaguColors[class].b)
  DEFAULT_CHAT_FRAME:AddMessage("|c"..shaguColors[class].colorStr..class.." colorStr Shagu"..FONT_COLOR_CODE_CLOSE)
  if RAID_CLASS_COLORS[class].r == shaguColors[class].r and
          RAID_CLASS_COLORS[class].g == shaguColors[class].g and
          RAID_CLASS_COLORS[class].b == shaguColors[class].b then
    DEFAULT_CHAT_FRAME:AddMessage(class .. " colors are a match")
  end
end

module.enable = function(self)
  -- update table to get unknown colors and blue shamans for vanilla
  local LOCAL_RAID_CLASS_COLORS = {
    ["WARRIOR"] = { r = 0.78, g = 0.61, b = 0.43, colorStr = "ffc79c6e" },
    ["MAGE"]    = { r = 0.41, g = 0.8,  b = 0.94, colorStr = "ff69ccf0" },
    ["ROGUE"]   = { r = 1,    g = 0.96, b = 0.41, colorStr = "fffff569" },
    ["DRUID"]   = { r = 1,    g = 0.49, b = 0.04, colorStr = "ffff7d0a" },
    ["HUNTER"]  = { r = 0.67, g = 0.83, b = 0.45, colorStr = "ffabd473" },
    ["SHAMAN"]  = { r = 0.14, g = 0.35, b = 1.0,  colorStr = "ff0070de" },
    ["PRIEST"]  = { r = 1,    g = 1,    b = 1,    colorStr = "ffffffff" },
    ["WARLOCK"] = { r = 0.58, g = 0.51, b = 0.79, colorStr = "ff9482c9" },
    ["PALADIN"] = { r = 0.96, g = 0.55, b = 0.73, colorStr = "fff58cba" },
  }

  printClass("WARRIOR", LOCAL_RAID_CLASS_COLORS)
  printClass("MAGE", LOCAL_RAID_CLASS_COLORS)
  printClass("ROGUE", LOCAL_RAID_CLASS_COLORS)
  printClass("DRUID", LOCAL_RAID_CLASS_COLORS)
  printClass("HUNTER", LOCAL_RAID_CLASS_COLORS)
  printClass("SHAMAN", LOCAL_RAID_CLASS_COLORS)
  printClass("PRIEST", LOCAL_RAID_CLASS_COLORS)
  printClass("WARLOCK", LOCAL_RAID_CLASS_COLORS)
  printClass("PALADIN", LOCAL_RAID_CLASS_COLORS)

  --RAID_CLASS_COLORS = setmetatable(RAID_CLASS_COLORS, { __index = function(tab,key)
  --  return { r = 0.6,  g = 0.6,  b = 0.6,  colorStr = "ff999999" }
  --end})
end
```

And here you can see it in game:
<img width="300" height="624" alt="image" src="https://github.com/user-attachments/assets/94637bf7-d432-4ef7-b321-56237f6489b0" />
<img width="335" height="190" alt="image" src="https://github.com/user-attachments/assets/9e323c99-3271-4906-b006-4db69b7ac4b0" />
