### PR TITLE
[Refactor/Improvement] Moved `GetItemLinkByName()` to `helpers.lua`

### DIFF
--- a/helpers.lua
+++ b/helpers.lua
@@ -346,3 +346,20 @@ ShaguTweaks.GetItemCount = function(itemName)
 
   return count
 end
+
+local itemLinkByNameCache = {}
+ShaguTweaks.GetItemLinkByName = function(name)
+  if itemLinkByNameCache[name] then
+    return itemLinkByNameCache[name]
+  end
+
+  for itemID = 1, 25818 do
+    local itemName, itemLink, itemQuality = GetItemInfo(itemID)
+    if (itemName and itemName == name) then
+      local _, _, _, hex = GetItemQualityColor(tonumber(itemQuality))
+      local hyperLink = hex.. "|H".. itemLink .."|h["..itemName.."]|h" .. FONT_COLOR_CODE_CLOSE
+      itemLinkByNameCache[name] = hyperLink
+      return hyperLink
+    end
+  end
+end

--- a/mods/vendor-values.lua
+++ b/mods/vendor-values.lua
@@ -3868,16 +3868,6 @@ end
 
 ShaguTweaks.SellValueDB = data
 
-local function GetItemLinkByName(name)
-  for itemID = 1, 25818 do
-    local itemName, hyperLink, itemQuality = GetItemInfo(itemID)
-    if (itemName and itemName == name) then
-      local _, _, _, hex = GetItemQualityColor(tonumber(itemQuality))
-      return hex.. "|H"..hyperLink.."|h["..itemName.."]|h|r"
-    end
-  end
-end
-
 local function AddVendorPrices(frame, id, count)
   if ShaguTweaks.SellValueDB[id] and ShaguTweaks.SellValueDB[id] > 0 then
     SetTooltipMoney(frame, ShaguTweaks.SellValueDB[id] * count)
@@ -3944,7 +3934,7 @@ module.enable = function(self)
   local HookSetInboxItem = GameTooltip.SetInboxItem
   function GameTooltip.SetInboxItem(self, mailID, attachmentIndex)
     local itemName, itemTexture, inboxItemCount, inboxItemQuality = GetInboxItem(mailID)
-    GameTooltip.itemLink = GetItemLinkByName(itemName)
+    GameTooltip.itemLink = ShaguTweaks.GetItemLinkByName(itemName)
     GameTooltip.ignoreMerchant = true
     return HookSetInboxItem(self, mailID, attachmentIndex)
   end
@@ -4007,7 +3997,7 @@ module.enable = function(self)
   function GameTooltip.SetAuctionSellItem(self)
     local itemName, _, itemCount = GetAuctionSellItemInfo()
     GameTooltip.itemCount = itemCount
-    GameTooltip.itemLink = GetItemLinkByName(itemName)
+    GameTooltip.itemLink = ShaguTweaks.GetItemLinkByName(itemName)
     GameTooltip.ignoreMerchant = true
     return HookSetAuctionSellItem(self)
   end

--- a/mods/vendor-values.lua
+++ b/mods/vendor-values.lua
@@ -1,6 +1,7 @@
 local _G = ShaguTweaks.GetGlobalEnv()
 local T = ShaguTweaks.T
 local GetExpansion = ShaguTweaks.GetExpansion
+local GetItemLinkByName = ShaguTweaks.GetItemLinkByName
 
 local module = ShaguTweaks:register({
   title = T["Vendor Values"],
@@ -3934,7 +3935,7 @@ module.enable = function(self)
   local HookSetInboxItem = GameTooltip.SetInboxItem
   function GameTooltip.SetInboxItem(self, mailID, attachmentIndex)
     local itemName, itemTexture, inboxItemCount, inboxItemQuality = GetInboxItem(mailID)
-    GameTooltip.itemLink = ShaguTweaks.GetItemLinkByName(itemName)
+    GameTooltip.itemLink = GetItemLinkByName(itemName)
     GameTooltip.ignoreMerchant = true
     return HookSetInboxItem(self, mailID, attachmentIndex)
   end
@@ -3997,7 +3998,7 @@ module.enable = function(self)
   function GameTooltip.SetAuctionSellItem(self)
     local itemName, _, itemCount = GetAuctionSellItemInfo()
     GameTooltip.itemCount = itemCount
-    GameTooltip.itemLink = ShaguTweaks.GetItemLinkByName(itemName)
+    GameTooltip.itemLink = GetItemLinkByName(itemName)
     GameTooltip.ignoreMerchant = true
     return HookSetAuctionSellItem(self)
   end


### PR DESCRIPTION
I am working on a new feature that will be using the `GetItemLinkByName()` function. Instead of duplicating it, I am moving it to the global helpers.

The resource usage of looping every item in the game when needed is quite high, so I opted for a dynamic programming solution, which reduces lookup times after an item has been seen once in a play session.

I tested looping every item in the `vendor-values.lua` data list to generated a complete static list of all names -> links. It was not successful as many links turned up empty, probably due to client side caching. Furthermore it would not have worked for clients in other languages.

## Changes
- Moved `GetItemLinkByName` to the general helpers
- Added dynamic programming to reduce looking resources usage.

## Tested OK. Vendor values still work for mail.