### PR TITLE
[New Feature] Show Lockpicking skills on tooltips

### DIFF
--- a/ShaguTweaks-tbc.toc
+++ b/ShaguTweaks-tbc.toc
@@ -75,3 +75,4 @@ mods\unitframes-bighealth.lua
 mods\unitframes-classportrait.lua
 mods\cooldown-numbers.lua
 mods\reduced-actionbar.lua
+mods\lockpicking-skills.lua

--- a/ShaguTweaks.toc
+++ b/ShaguTweaks.toc
@@ -79,3 +79,4 @@ mods\cooldown-numbers.lua
 mods\turtle-wow.lua
 mods\superwow.lua
 mods\reduced-actionbar.lua
+mods\lockpicking-skills.lua

--- a/helpers.lua
+++ b/helpers.lua
@@ -367,3 +367,16 @@ ShaguTweaks.GetItemLinkByName = function(name)
     end
   end
 end
+
+ShaguTweaks.GetItemIDFromLink = function(itemLink)
+  if not itemLink then
+    return
+  end
+
+  local foundID, _ , itemID = string.find(itemLink, "item:(%d+)")
+  if not foundID then
+    return
+  end
+
+  return tonumber(itemID)
+end

--- a/mods/lockpicking-skills.lua
+++ b/mods/lockpicking-skills.lua
@@ -25,11 +25,14 @@ local requirePickPocketSkill = {
     [5759]  = 225, -- Thorium Lockbox
     [5760]  = 225, -- Eternium Lockbox
     [31952] = 325, -- Khorium Lockbox - TBC
+    [43622] = 375, -- Froststeel Lockbox - WotLK
+    [43624] = 400, -- Titanium Lockbox - WotLK
     -- Fishing
     [6354]  = 1,   -- Small Locked Chest
     [6355]  = 70,  -- Sturdy Locked Chest
     [13875] = 175, -- Ironbound Locked Chest
     [13918] = 250, -- Reinforced Locked Chest
+    [45986] = 400, -- Tiny Titanium Lockbox - WotLK
     -- Engineering
     [6712]  = 1    -- Practice Lock
 }

--- a/mods/lockpicking-skills.lua
+++ b/mods/lockpicking-skills.lua
@@ -59,6 +59,11 @@ if GetExpansion() == "tbc" then
     end
 end
 
+-- In WotLK keys already say what level they can open, but Seaforium does not.
+if GetExpansion() == "wotlk" then
+    canOpenPickPocketSkill = tbcSeaforiumCharge
+end
+
 local function AddLockPickingSkill(frame, itemLink)
     if not frame then return end
 

--- a/mods/lockpicking-skills.lua
+++ b/mods/lockpicking-skills.lua
@@ -75,9 +75,12 @@ local function AddLockPickingSkill(frame, itemLink)
         lineString = string.format("Opens lock up to (%d) lockpicking skill", canOpenPickPocketSkill[itemID])
     end
 
-    -- Ensure line is added above the money line
     local moneyFrame = _G[frame:GetName().."MoneyFrame"]
-    if moneyFrame and moneyFrame.staticMoney then
+    local isMoneyShownOnTooltip = MerchantFrame:IsVisible()
+            or moneyFrame and moneyFrame.staticMoney > 0 and moneyFrame.staticMoney ~= GetMoney()
+
+    -- Ensure line is added above the money line
+    if isMoneyShownOnTooltip then
         moneyFrame:Hide()
         for i = frame:NumLines(), 1, -1 do
             local line = _G[frame:GetName().."TextLeft"..i]
@@ -88,7 +91,7 @@ local function AddLockPickingSkill(frame, itemLink)
         end
         SetTooltipMoney(frame, moneyFrame.staticMoney) -- add the money one line down
     else
-        frame:AddLine(lineString)
+        frame:AddLine(lineString, 1.0, 1.0, 1.0)
     end
 
     frame:Show()

--- a/mods/lockpicking-skills.lua
+++ b/mods/lockpicking-skills.lua
@@ -75,12 +75,9 @@ local function AddLockPickingSkill(frame, itemLink)
         lineString = string.format("Opens lock up to (%d) lockpicking skill", canOpenPickPocketSkill[itemID])
     end
 
-    local moneyFrame = _G[frame:GetName().."MoneyFrame"]
-    local isMoneyShownOnTooltip = MerchantFrame:IsVisible()
-            or moneyFrame and moneyFrame.staticMoney > 0 and moneyFrame.staticMoney ~= GetMoney()
-
     -- Ensure line is added above the money line
-    if isMoneyShownOnTooltip then
+    local moneyFrame = _G[frame:GetName().."MoneyFrame"]
+    if moneyFrame and moneyFrame:IsVisible() then
         moneyFrame:Hide()
         for i = frame:NumLines(), 1, -1 do
             local line = _G[frame:GetName().."TextLeft"..i]

--- a/mods/lockpicking-skills.lua
+++ b/mods/lockpicking-skills.lua
@@ -1,0 +1,176 @@
+local _G = ShaguTweaks.GetGlobalEnv()
+local L, T = ShaguTweaks.L, ShaguTweaks.T
+local GetExpansion = ShaguTweaks.GetExpansion
+local hooksecurefunc = ShaguTweaks.hooksecurefunc
+local GetItemIDFromLink = ShaguTweaks.GetItemIDFromLink
+local GetItemLinkByName = ShaguTweaks.GetItemLinkByName
+
+local module = ShaguTweaks:register({
+    title = T["Lockbox and Key skills"],
+    description = T["Adds the Lockpicking skill required to unlock a lockbox on the tooltip. Blacksmithing keys show what level they can unlock."],
+    expansions = { ["vanilla"] = true, ["tbc"] = true },
+    category = T["Tooltip & Items"],
+    enabled = true,
+})
+
+local requirePickPocketSkill = {
+    -- Drops
+    [4632]  = 1,   -- Ornate Bronze Lockbox
+    [4633]  = 25,  -- Heavy Bronze Lockbox
+    [4634]  = 70,  -- Iron Lockbox
+    [4636]  = 125, -- Strong Iron Lockbox
+    [4637]  = 175, -- Steel Lockbox
+    [4638]  = 225, -- Reinforced Steel Lockbox
+    [5758]  = 225, -- Mithril Lockbox
+    [5759]  = 225, -- Thorium Lockbox
+    [5760]  = 225, -- Eternium Lockbox
+    [31952] = 325, -- Khorium Lockbox - TBC
+    -- Fishing
+    [6354]  = 1,   -- Small Locked Chest
+    [6355]  = 70,  -- Sturdy Locked Chest
+    [13875] = 175, -- Ironbound Locked Chest
+    [13918] = 250, -- Reinforced Locked Chest
+    -- Engineering
+    [6712]  = 1    -- Practice Lock
+}
+
+local canOpenPickPocketSkill = {
+    -- Blacksmithing
+    [15869] = 25,  -- Silver Skeleton Key
+    [15870] = 125, -- Gold Skeleton Key
+    [15871] = 200, -- Truesilver Skeleton Key
+    [15872] = 300, -- Arcanite Skeleton Key
+}
+
+-- In TBC Seaforium charge can open chests in addition to doors.
+local tbcSeaforiumCharge = {
+    [4367]  = 150, -- Small Seaforium Charge
+    [4398]  = 250, -- Large Seaforium Charge
+    [18594] = 300, -- Powerful Seaforium Charge
+    [23819] = 350, -- Elemental Seaforium Charge
+}
+
+if GetExpansion() == "tbc" then
+    for k,v in pairs(tbcSeaforiumCharge) do
+        canOpenPickPocketSkill[k] = v
+    end
+end
+
+local function AddLockPickingSkill(frame, itemLink)
+    if not frame then return end
+
+    local itemID = GetItemIDFromLink(itemLink)
+    if not itemID then return end
+
+    if not requirePickPocketSkill[itemID] and not canOpenPickPocketSkill[itemID] then
+        return
+    end
+
+    local lineString
+    if requirePickPocketSkill[itemID] then
+        lineString = string.format("Requires Lockpicking (%d)", requirePickPocketSkill[itemID])
+    end
+
+    if canOpenPickPocketSkill[itemID] then
+        lineString = string.format("Opens lock up to (%d) lockpicking skill", canOpenPickPocketSkill[itemID])
+    end
+
+    -- Ensure line is added above the money line
+    local moneyFrame = _G[frame:GetName().."MoneyFrame"]
+    if moneyFrame and moneyFrame.staticMoney then
+        moneyFrame:Hide()
+        for i = frame:NumLines(), 1, -1 do
+            local line = _G[frame:GetName().."TextLeft"..i]
+            if line:GetText() == " " then -- the money line
+                line:SetText(lineString) -- use money line to hold text
+                break
+            end
+        end
+        SetTooltipMoney(frame, moneyFrame.staticMoney) -- add the money one line down
+    else
+        frame:AddLine(lineString)
+    end
+
+    frame:Show()
+end
+
+module.enable = function(self)
+    -- Hook item links tooltip
+    hooksecurefunc("ChatFrame_OnHyperlinkShow", function(link, text, button)
+        AddLockPickingSkill(ItemRefTooltip, link)
+    end)
+
+    -- Hook loot tooltip
+    hooksecurefunc(GameTooltip, "SetLootItem", function(tip, lootIndex)
+        AddLockPickingSkill(GameTooltip, GetLootSlotLink(lootIndex))
+    end)
+
+    -- Hook group loot roll tooltip
+    hooksecurefunc(GameTooltip, "SetLootRollItem", function(tip, id)
+        AddLockPickingSkill(GameTooltip, GetLootRollItemLink(id))
+    end)
+
+    -- Hook bag tooltip
+    hooksecurefunc(GameTooltip, "SetBagItem", function(tip, bag, slot)
+        AddLockPickingSkill(GameTooltip, GetContainerItemLink(bag, slot))
+    end)
+
+    -- Hook bank tooltip
+    hooksecurefunc(GameTooltip, "SetInventoryItem", function(tip, unit, slot)
+        AddLockPickingSkill(GameTooltip, GetInventoryItemLink(unit, slot))
+    end)
+
+    -- Hook hyper links, used for BankItems and Bagnon_Forever addons
+    hooksecurefunc(GameTooltip, "SetHyperlink", function(tip, link, count)
+        AddLockPickingSkill(GameTooltip, link)
+    end)
+
+    -- Hook quest reward tooltip
+    hooksecurefunc(GameTooltip, "SetQuestItem", function(tip, qtype, slot)
+        AddLockPickingSkill(GameTooltip, GetQuestItemLink(qtype, slot))
+    end)
+
+    -- Hook questlog reward tooltip
+    hooksecurefunc(GameTooltip, "SetQuestLogItem", function(tip, qtype, slot)
+        AddLockPickingSkill(GameTooltip, GetQuestLogItemLink(qtype, slot))
+    end)
+
+    -- Hook trade skill tooltip
+    hooksecurefunc(GameTooltip, "SetTradeSkillItem", function(tip, tradeItemIndex, reagentIndex)
+        if reagentIndex then
+            return AddLockPickingSkill(GameTooltip, GetTradeSkillReagentItemLink(tradeItemIndex, reagentIndex))
+        end
+
+        AddLockPickingSkill(GameTooltip, GetTradeSkillItemLink(tradeItemIndex))
+    end)
+
+    -- Hook player trade tooltip
+    hooksecurefunc(GameTooltip, "SetTradePlayerItem", function(self, index)
+        AddLockPickingSkill(GameTooltip, GetTradePlayerItemLink(index))
+    end)
+
+    -- Hook target trade tooltip
+    hooksecurefunc(GameTooltip, "SetTradeTargetItem", function(self, index)
+        AddLockPickingSkill(GameTooltip, GetTradeTargetItemLink(index))
+    end)
+
+    -- Hook inbox items
+    hooksecurefunc(GameTooltip, "SetInboxItem", function(self, mailIndex, attachmentIndex)
+        if GetInboxItemLink then
+            return AddLockPickingSkill(GameTooltip, GetInboxItemLink(mailIndex, attachmentIndex))
+        end
+
+        local itemName = GetInboxItem(mailIndex, attachmentIndex)
+        AddLockPickingSkill(GameTooltip, GetItemLinkByName(itemName))
+    end)
+
+    -- Hook send mail items
+    hooksecurefunc(GameTooltip, "SetSendMailItem", function(self, attachmentIndex)
+        if GetSendMailItemLink then
+            return AddLockPickingSkill(GameTooltip, GetSendMailItemLink(attachmentIndex))
+        end
+
+        local itemName = GetSendMailItem(attachmentIndex)
+        AddLockPickingSkill(GameTooltip, GetItemLinkByName(itemName))
+    end)
+end


### PR DESCRIPTION
# New Feature
- Add the required lockpicking skill to the tooltip of lockboxes.
- Add the lockpicking skill a blacksmith key kan open to the tooltip
- **TBC:** Add the lockpicking skill to Seaforium charge tooltips
  - In Vanilla Seaforium can only open doors. In TBC and onwards it can open lockboxes and chests
- **WotLK:** Blizzard added the lockpicking skill of keys directly to the tooltip so the addon ignores keys. The addon still handles Seaforium as it did not get a skill added.
  - <img width="444" height="233" alt="image" src="https://github.com/user-attachments/assets/2763511e-1d92-4070-89c6-87b4a80fb48a" />

Here are images of how it looks:
| Location | Lockbox| Key |
|--------|--------|--------|
| **In bag**| <img width="290" height="144" alt="lockbox1" src="https://github.com/user-attachments/assets/9b3ce4ff-0020-47c9-8a70-a44dc825dc9e" /> | <img width="359" height="194" alt="key1" src="https://github.com/user-attachments/assets/2b6f664d-9224-4e5b-96b4-2a4219e05cb1" /> |
| **At Vendor** | <img width="292" height="162" alt="lockbox2" src="https://github.com/user-attachments/assets/3625f211-83dd-450b-bd6b-5eb49ae6953e" /> | <img width="379" height="205" alt="key3" src="https://github.com/user-attachments/assets/fbfd76e0-8231-41b9-8769-7538bf92418a" /> |
| **With Vendor Values active** | <img width="295" height="166" alt="lockbox3" src="https://github.com/user-attachments/assets/90d173ec-90ce-44b4-b8ba-eed73a58921d" /> | <img width="377" height="205" alt="key2" src="https://github.com/user-attachments/assets/a102167c-18ef-409a-a98b-4f9baaa5741a" /> |

## Improvements
Added a helper function `GetItemIDFromLink()` as multiple modules already do this in various different way. This will help streamline the codebase over time.

## Future additions
I would like to add the lockpicking skill to locked chests and doors in the open world, but that requires further investigation on how to do that in a beatiful way.