### PR TITLE
[Improvement] Sort the `General` category to the top

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -123,7 +123,19 @@ settings.load = function(self)
   local entrysize = 22
   local previous = nil
 
-  for category, entries in ShaguTweaks.spairs(gui) do
+  local sortedKeys = {}
+  for key, value in pairs(gui) do
+    table.insert(sortedKeys, key)
+  end
+
+  table.sort(sortedKeys, function(a, b)
+    if a == T["General"] then return true end
+    if b == T["General"] then return false end
+    return a < b
+  end)
+
+  for _, category in ipairs(sortedKeys) do
+    local entries = gui[category]
     local entry, spacing = 1, 22
     local height = 0
 


### PR DESCRIPTION
Sort categories so that the `General` category is at the top. All other categories are sorted aplhabetically afterwards.

You can probably do it smarter or cleaner with your `ShaguTweaks.spairs(gui)` but I did not know how to modify that function.