### PR TITLE
[Improvement] Extend `ShaguTweaks.spairs` with an optional comparator function

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -123,19 +123,13 @@ settings.load = function(self)
   local entrysize = 22
   local previous = nil
 
-  local sortedKeys = {}
-  for key, value in pairs(gui) do
-    table.insert(sortedKeys, key)
-  end
-
-  table.sort(sortedKeys, function(a, b)
+  local sortGeneralFirst = function(a, b)
     if a == T["General"] then return true end
     if b == T["General"] then return false end
     return a < b
-  end)
+  end
 
-  for _, category in ipairs(sortedKeys) do
-    local entries = gui[category]
+  for category, entries in ShaguTweaks.spairs(gui, sortGeneralFirst) do
     local entry, spacing = 1, 22
     local height = 0
 

--- a/config.lua
+++ b/config.lua
@@ -118,12 +118,24 @@ settings.load = function(self)
     end
   end
 
+  local sortedKeys = {}
+  for key, value in pairs(gui) do
+    table.insert(sortedKeys, key)
+  end
+
+  table.sort(sortedKeys, function(a, b)
+    if a == T["General"] then return true end
+    if b == T["General"] then return false end
+    return a < b
+  end)
+
   local topspace = 10
   local required_height = topspace
   local entrysize = 22
   local previous = nil
 
-  for category, entries in ShaguTweaks.spairs(gui) do
+  for _, category in ipairs(sortedKeys) do
+    local entries = gui[category]
     local entry, spacing = 1, 22
     local height = 0
 

--- a/helpers.lua
+++ b/helpers.lua
@@ -296,19 +296,18 @@ ShaguTweaks.TimeConvert = function(remaining)
 end
 
 -- http://lua-users.org/wiki/SortedIteration
-local function __genOrderedIndex( t )
+local function __genOrderedIndex(t, sortFunc)
   local orderedIndex = {}
   for key in pairs(t) do
     table.insert( orderedIndex, key )
   end
-  table.sort( orderedIndex )
+  table.sort(orderedIndex, sortFunc)
   return orderedIndex
 end
 
 local function orderedNext(t, state)
   local key = nil
   if state == nil then
-    t.__orderedIndex = __genOrderedIndex( t )
     key = t.__orderedIndex[1]
   else
     for i = 1,table.getn(t.__orderedIndex) do
@@ -326,7 +325,12 @@ local function orderedNext(t, state)
   return
 end
 
-ShaguTweaks.spairs = function(t)
+ShaguTweaks.spairs = function(t, sortFunc)
+  if sortFunc ~= nil and type(sortFunc) ~= "function" then
+    error("ShaguTweaks.spairs: expected a function for sortFunc, got " .. type(sortFunc))
+  end
+
+  t.__orderedIndex = __genOrderedIndex(t, sortFunc)
   return orderedNext, t, nil
 end
 

--- a/main.lua
+++ b/main.lua
@@ -83,7 +83,7 @@ ShaguTweaks.register = function(self, mod)
   -- add fallback captions and providers to categories
   local provider = ShaguTweaks.provider or "|cffFF5555Mods:|r"
   local category = mod.category or ShaguTweaks.T["General"]
-  mod.category = official and category or provider .. " " .. category
+  mod.category = category or provider .. " " .. category
 
   -- register mod
   ShaguTweaks.mods[mod.title] = mod

--- a/main.lua
+++ b/main.lua
@@ -83,7 +83,7 @@ ShaguTweaks.register = function(self, mod)
   -- add fallback captions and providers to categories
   local provider = ShaguTweaks.provider or "|cffFF5555Mods:|r"
   local category = mod.category or ShaguTweaks.T["General"]
-  mod.category = category or provider .. " " .. category
+  mod.category = official and category or provider .. " " .. category
 
   -- register mod
   ShaguTweaks.mods[mod.title] = mod


### PR DESCRIPTION
## Your code deserves better!

We talked about extending the `spairs` function and here it is.

I did not know how to do this directly, but after sleeping on it and asking an AI for help, we figured we could add the sort function as shown.

I added some error handling, for completeness sake, but you can remove it if you find it redundant.

This should be safe as the function
```
local function orderedNext(t, state)
  local key = nil
  if state == nil then -- Only nil on first iteration
    t.__orderedIndex = __genOrderedIndex( t )
    ...
  end
  ...

   t.__orderedIndex = nil -- custom sorter is removed again.
  return
end
```
only has `state == nil` on the first iteration, where the orderedIndex would normally be set.

Furthermore the custom sorter is removed again in the end, so nothing is persisted on the table.

I have tested it, and it works as expected on the Advanced Options window:
<img width="886" height="610" alt="image" src="https://github.com/user-attachments/assets/fbc5b1df-c5c6-4613-a339-392803935641" />