### PR TITLE
Optimize Minimap Clock Updates

### DIFF
--- a/mods/minimap-clock.lua
+++ b/mods/minimap-clock.lua
@@ -32,8 +32,12 @@ module.enable = function(self)
   MinimapClock.text:SetFont(STANDARD_TEXT_FONT, 12, "OUTLINE")
   MinimapClock.text:SetAllPoints(MinimapClock)
   MinimapClock.text:SetFontObject(GameFontWhite)
+  local nextUpdate = 0
   MinimapClock:SetScript("OnUpdate", function()
-    this.text:SetText(date("%H:%M"))
+    if nextUpdate <= GetTime() then
+      nextUpdate = GetTime() + 1
+      this.text:SetText(date("%H:%M"))
+    end
   end)
 
   MinimapClock:SetScript("OnEnter", function()


### PR DESCRIPTION
Running at 120 FPS, the minimap clock consumes just under 1 millisecond/second compute time on my computer. This optimization seems to reduce this by around 85-90%.